### PR TITLE
Update Community

### DIFF
--- a/src/.vuepress/navbar.ts
+++ b/src/.vuepress/navbar.ts
@@ -59,7 +59,7 @@ export const enNavbarConfig = navbar([
       },
       {
         text: "Community",
-        children: ["code-of-conduct", "duties-and-rigths"],
+        children: ["code-of-conduct", "duties-and-rigths", "community-detail" ],
       },
     ],
   },

--- a/src/community/citizens/citizen-application-form.md
+++ b/src/community/citizens/citizen-application-form.md
@@ -1,0 +1,51 @@
+---
+title: Citizen Application Form
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Citizens
+article: false
+---
+
+The following form is to be filled out by citizens applicants and sent to the Community Council Team via cc at adempiere.net :
+
+___
+
+- First Name:
+- Surname:
+- Street:
+- ZIP/City:
+- Country:
+- Email Address:
+- SF User:
+- Wiki User:
+- atlassian User:
+- Company:
+  
+- Link to Post of your nominator:
+- Link to Post of your supporter #1:
+- Link to Post of your supporter #2:
+
+I `<YOUR NAME>` would like to become an ADempiere citizen.
+
+I commit myself to the goals of the ADempiere project. I will help to advance the project and not harm it in any way.
+
+Furthermore I am aware that becoming a citizen implies a commitment to the spirit of the rules and bodies elected by the community and listed below in the PS. In particular, I am aware that an amicable, cooperative and sympathetic behavior is most important for having excellent relationships within citizens.
+
+My contributions to the community have been the following (short list of contributions) and I will contribute in the future the following way (short explanation). `<Your Contributions - short list>`
+
+`<My planned future Contributions - short explanation>`
+
+The following Links I will follow and respect:
+
+- Citizens: http://www.adempiere.com/Community
+- Community Governance: http://www.adempiere.com/Community_Governance
+- Communication Guidelines: http://www.adempiere.com/Communication_Guidelines
+- Software Development Procedure: https://www.adempierebr.com/Software_Development_Procedure
+
+I am also aware that not acting in a proper way may lead to losing my citizenship.
+
+Regards,
+
+`<YOUR NAME>`

--- a/src/community/citizens/citizen-elections-archive.md
+++ b/src/community/citizens/citizen-elections-archive.md
@@ -1,0 +1,47 @@
+---
+title: Citizen Elections Archive
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Citizens
+article: false
+---
+
+This is the archive for this page: [Citizen Elections](../citizens/citizen-elections.md)
+
+Name | SF nick | application form received | Nominater | Supporter#1 | Supporter#2 | Status
+-- | -- | -- | -- | -- | -- | --
+`<Name>` | `<SF-Nick>` | `<Yes/No>` | Link | Link#1 | Link#2 | result: accepted/rejected
+Ricardo Santana | ralexsander | Yes | [1](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865) | [2](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865) | [3](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865) | accepted 16.07.2012
+Silvano Trinchero | freepath | Yes | [1](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865) | [2](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865) | [3](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865) | accepted 16.07.2012
+Azzam Othman | azzamahmad | Yes | [1](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4838257) | [1](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4838257) | [1](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4838257) | accepted 16.07.2012
+Alberto Abudinen | albertoabudinen | Yes | NA | NA | NA | accepted 16.07.2012
+Hilario Fochi | fochi | Yes | [1](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865) | [1](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865) | [1](https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865) | accepted 16.07.2012|
+
+## 2011 - November
+
+- Source: https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4838257/index/page/1 
+- Source: https://sourceforge.net/projects/adempiere/forums/forum/611167/topic/4850865/index/page/1
+
+Nominees (Status: Nomination to be documented):
+
+- Emiliano González
+- Marcos Zuñiga
+- Emiliano Pereyra
+- Ricardo Santana
+- Fernando de Oliveira Moraes
+- Hilario Fochi
+- Murilo Habberman Torquato
+- Claudemir Todo Bom
+- Silvano Trinchero (SF login: freepath)
+- Jacken Chan
+- Peanut Blake
+- Thomas Bayen (tbayen) (https://sourceforge.net/projects/adempiere/forums/forum/610548/topic/4829973?message=10837953)
+- Dan Cimpoesu (3x Nominations: [1] [2] [3]
+- Orlando Curieles (doubleclickca)
+- Jenny Rodriguez (jennycecilia)
+- Didiber
+- Vosskaem
+- nberisha
+- Anuj Agarwal (agarwalanuj)

--- a/src/community/citizens/citizen-elections.md
+++ b/src/community/citizens/citizen-elections.md
@@ -1,0 +1,32 @@
+---
+title: Citizen Elections
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Citizens
+article: false
+---
+
+Page contains new citizen applicants. Once voted the entries are moved to Citizens.
+
+Please read here [How to become a citizen](../community-detail.md).
+
+Procedure:
+
+1. A nominator who is already a citizen needs to nominates you for citizenship in the SF Forum or via email to cc at adempiere.net
+
+2. Two supporters who are already citizen need to second the nomination
+
+3. Fill out this [Citizen Application Form](../citizens/citizen-application-form.md).
+
+4. After receiving your form CC will put your name to this page
+
+5. When a bunch of nominees are listed CC will start a vote via limesurvey
+
+6. When voted your entry will be moved from here to the [Citizen List](../citizens/citizens.md) and a copy will be archived here [Citizen Elections Archive](../citizens/citizen-elections-archive.md).
+
+| Name                     | SF nick   | Application form Received | Nominator | Supporter#1 | Supporter#2 | Status                 | Old Citizen ID |
+|--------------------------|-----------|---------------------------|-----------|-------------|-------------|------------------------|----------------|
+| Sarafudheen M.Tharayil   | sarafudheen | Yes                      | [Link](http://sourceforge.net/projects/adempiere/forums/forum/611167/topic/5424139) | [Link](http://sourceforge.net/projects/adempiere/forums/forum/611167/topic/5424139) | [Link](http://sourceforge.net/projects/adempiere/forums/forum/611167/topic/5424139) | New/waiting for vote   |   -              |
+| John Daison Agudelo     | jdaison   | Yes                      | [Link](http://sourceforge.net/projects/adempiere/forums/forum/611167/topic/5453559) | [Link](http://sourceforge.net/projects/adempiere/forums/forum/611167/topic/5453559) | [Link](http://sourceforge.net/projects/adempiere/forums/forum/611167/topic/5453559) | New/waiting for vote   |   -              |

--- a/src/community/citizens/citizens-inactive.md
+++ b/src/community/citizens/citizens-inactive.md
@@ -1,0 +1,88 @@
+---
+title: Citizens Inactive
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Citizens
+article: false
+---
+
+No | Name | Email | IRC nick | SF nick | Date of Entrance | Reference | Residence | Status
+-- | -- | -- | -- | -- | -- | -- | -- | --
+54 | Andrés Cárdenas |   |   |   | 11.09.2009 |   |   | Inactive
+55 | Ariel A. Rosenbrock |   |   |   | 11.09.2009 |   | Argentina | Inactive
+56 | Benjamin Enrique Garcia |   |   |   | 11.09.2009 |   |   | Inactive
+57 | Camilo Parra |   |   |   | 11.09.2009 |   | Colombia | Inactive
+40 | Chris Ian Fiel |   |   |   | 24.08.2009 |   | Philippines | Inactive
+58 | Diego Carrero |   |   |   | 11.09.2009 |   |   | Inactive
+42 | Holger Dittmann |   |   |   | 24.08.2009 |   | Germany | Inactive
+30 | Ioan Bogdan |   |   |   | 6.08.2009 |   | Romania | Inactive
+64 | Iveen Duarte |   |   |   | 11.09.2009 |   |   | Inactive
+67 | Jesús García |   |   |   | 11.09.2009 |   | Colombia | Inactive
+44 | Joao Boto |   |   |   | 24.08.2009 |   | Portugal | Inactive
+27 | Joerg Viola |   |   |   | 3.08.2009 |   | Germany | Inactive
+52 | John MacDonald |   |   |   | 24.08.2009 |   |   | Inactive
+71 | Joseph Brower |   |   |   | 11.09.2009 |   | USA | Inactive
+74 | Leonardo Gutierrez |   |   |   | 11.09.2009 |   | Colombia | Inactive
+75 | Leonardo Reyes |   |   |   | 11.09.2009 |   | Colombia | Inactive
+77 | Manuel Quinteiro |   |   |   | 11.09.2009 |   | Spain | Inactive
+24 | Moses Wangaruro Kariuki |   |   |   | 3.08.2009 |   | Kenya | Inactive
+32 | Ngigi Waithaka |   |   |   | 6.08.2009 |   | Kenya | Inactive
+79 | Paula Miller |   |   |   | 11.09.2009 |   |   | Inactive
+20 | Peter De Zutter |   |   |   | 2.08.2009 |   | Belgium | Inactive
+36 | Praneet Tiwari |   |   |   | 11.08.2009 |   | India | Inactive
+81 | Ruben Alberto Urbe Rosas |   |   |   | 11.09.2009 |   |   | Inactive
+85 | Russ Herrold |   |   |   |   |   | USA | Inactive
+50 | Satyaakam Goswami |   |   |   | 24.08.2009 |   |   | Inactive
+51 | Syamsul Anuar Abd Nasir |   |   |   | 24.08.2009 |   |   | Inactive
+82 | Victor Capuggi |   |   |   | 11.09.2009 |   |   | Inactive
+1 | Redhuan D. Oon |   |   |   | 23.06.2009 |   | Malaysia | Inactive - Survey Jan 2018 - no response
+4 | Teo Sarca |   |   |   | 23.06.2009 |   | Romania | Inactive by request - Survey Jan 2018
+5 | Heng Sin |   |   |   | 07.07.2009 |   | Malaysia | Inactive by request - Survey Jan 2018
+9 | Karsten Thiemann |   |   |   | 07.07.2009 |   | Germany | Inactive - Survey Jan 2018 - no response
+12 | Paul Bowden |   |   |   | 07.07.2009 |   | Australia | Inactive - Survey Jan 2018 - no response
+13 | Norbert Wessel |   |   |   | 07.07.2009 |   | Germany | Inactive by request - Survey Jan 2018
+15 | Tobias Schoenenberg |   |   |   | 07.07.2009 |   | Germany | Inactive by request - Survey Jan 2018
+17 | Bayu Cahya P |   |   |   | 2.08.2009 |   | Indonesia | Inactive - Survey Jan 2018 - No contact info
+18 | Daniel Tamm |   |   |   | 2.08.2009 |   | Sweden | Inactive - Survey Jan 2018 - No contact info
+19 | Dominik Zajac |   |   |   | 2.08.2009 |   | Germany | Inactive - Survey Jan 2018 - no response
+22 | Tony Snook |   |   |   | 2.08.2009 |   | Australia | Inactive - Survey Jan 2018 - no response
+23 | Angelo Dabalà |   |   |   | 3.08.2009 |   | Italy | Inactive - Survey Jan 2018 - No contact info
+26 | Dirk Niemeyer |   |   |   | 3.08.2009 |   | Germany | Inactive - Survey Jan 2018 - no response
+28 | Cristina Ghita |   |   |   | 6.08.2009 |   | Romania | Inactive - Survey Jan 2018 - no response
+34 | Joel Hoffman |   |   |   | 11.08.2009 |   | USA | Inactive by request (Opt Out)
+35 | Joel Stangeland |   |   |   | 11.08.2009 |   | USA | Inactive - Survey Jan 2018 - No contact info
+39 | Antoni Ten |   |   |   | 24.08.2009 |   | Spain | Inactive - Survey Jan 2018 - No contact info
+41 | Edwin Ang |   |   |   | 24.08.2009 |   | Singapore | Inactive - Survey Jan 2018 - no response
+43 | Ivan Calderon |   |   |   | 24.08.2009 |   | Spain | Inactive - Survey Jan 2018 - no response
+45 | Jovansonlee Cesar |   |   |   | 24.08.2009 |   | Philippines | Inactive - Survey Jan 2018 - No contact info
+46 | Kang Ngiap. Hee |   |   |   | 24.08.2009 |   |   | Inactive - Survey Jan 2018 - no response
+48 | Paul Aviles |   |   |   | 24.08.2009 |   | USA | Inactive - Survey Jan 2018 - no response
+60 | Fabian Aguilar |   |   |   | 11.09.2009 |   | Chile | Inactive - Survey Jan 2018 - no response
+61 | Fernando Saavedra |   |   |   | 11.09.2009 |   | Ecuador | Inactive - Survey Jan 2018 - no response
+62 | Fred Blauer |   |   |   | 11.09.2009 |   |   | Inactive by request (Opt Out)
+63 | Gustavo Vega Q. |   |   |   | 11.09.2009 |   | Ecuador | Inactive - Survey Jan 2018 - no response
+65 | Javier Carvajal |   |   |   | 11.09.2009 |   |   | Inactive - Survey Jan 2018 - no response
+66 | Jens Pfeiffer |   |   |   | 11.09.2009 |   |   | Inactive - Survey Jan 2018 - no response
+68 | Jorge Iván Tabares |   |   |   | 11.09.2009 |   |   | Inactive - Survey Jan 2018 - No contact info
+70 | José Antonio Pons |   |   |   | 11.09.2009 |   | Spain | Inactive by request (Opt Out)
+72 | Juan C. Cavo |   |   |   | 11.09.2009 |   | Argentina | Inactive - Survey Jan 2018 - Incomplete (assume No)
+73 | Layda Salas |   |   |   | 11.09.2009 |   | Colombia | Inactive - Survey Jan 2018 - no response
+76 | Luis Felipe Castilla |   |   |   | 11.09.2009 |   | Colombia | Inactive - Survey Jan 2018 - no response
+78 | Miguel Hernández Giusti |   |   |   | 11.09.2009 |   |   | Inactive - Survey Jan 2018 - No contact info
+80 | Rafael Dominguez |   |   |   | 11.09.2009 |   |   | Inactive - Survey Jan 2018 - No contact info
+83 | Yogan Naidoo |   |   |   | 11.09.2009 |   |   | Inactive by request (Opt Out)
+84 | Carlos Ruiz |   |   |   |   |   | Colombia | Inactive - Survey Jan 2018 - no response
+86 | Thomas Kreser |   |   |   | 26.10.2009 |   | Germany | Inactive - Survey Jan 2018 - No contact info
+87 | Fernando Lucktemberg |   |   |   | 22.12.2009 |   | Brazil | Inactive - Survey Jan 2018 - no response
+89 | Pedro Rozo |   |   |   | 21.12.2010 |   | Colombia | Inactive - Survey Jan 2018 - no response
+90 | Jireh Arciaga |   |   |   | 21.12.2010 |   |   | Inactive - Survey Jan 2018 - no response
+91 | Sergio Trillo |   |   |   | 21.12.2010 |   | Spain/Barcelona | Inactive - Survey Jan 2018 - No contact info
+92 | Muhammad Nasir Aftab |   |   |   | 21.12.2010 |   | Pakistan | Inactive - Survey Jan 2018 - no response
+93 | Kitti Upariphutthiphong |   |   |   | 21.12.2010 |   | Thailand | Inactive - Survey Jan 2018 - no response
+94 | Ayaz Ahmed |   |   |   | 21.12.2010 |   | Karachi, Pakistan | Inactive - Survey Jan 2018 - no response
+95 | Peter Shepetko |   |   |   | 21.12.2010 |   | Ukraine | Inactive - Survey Jan 2018 - no response
+96 | Kakhaber Kheladze |   |   |   | 21.12.2010 |   | Georgia | Inactive - Survey Jan 2018 - No contact info
+98 | Ricardo Santana |   |   |   | 16.07.2012 |   |   | Inactive - Survey Jan 2018 - Incomplete (assume No)
+99 | Silvano Trinchero |   |   |   | 16.07.2012 |   |   | Inactive - Survey Jan 2018 |

--- a/src/community/citizens/citizens.md
+++ b/src/community/citizens/citizens.md
@@ -1,0 +1,46 @@
+---
+title: Citizens
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Citizens
+article: false
+---
+
+The citizens of ADempiere Community are known members able to vote on certain project decisions. All citizens can be found on the mailling list "adempiere-citizens".
+
+Please see the discussion about defining our [Community](../community-detail.md). [Citizen Elections](/community/citizens/citizen-elections.md) are ongoing.
+
+Here you find [Inactive Citizens](../citizens/citizens-inactive.md).
+
+No | Name | Email | IRC nick | SF nick | Date of Entrance | Reference | Residence | Status
+-- | -- | -- | -- | -- | -- | -- | -- | --
+`<No>` | `<Name>` | `<email>` | `<irc>` | `<SF>` | `<date>` |   |   | `<Active/Passive/nominated/applying>`
+2 | [Victor Perez](https://wiki.adempiere.net/User:Vpj-cd) | [e-mail](mailto:victor.perez@e-evolution.com) | `<irc>` | [vpj-cd](http://sourceforge.net/users/vpj-cd/) | 23.06.2009 | <http://e-evolution.com> | Mexico | Active
+3 | [Trifon Trifonov](https://wiki.adempiere.net/User:Trifonnt) | `<email>` | trifon | [trifonnt](http://sourceforge.net/users/trifonnt) | 23.06.2009 | [www.d3soft.biz](http://www.d3soft.biz/) | Europe | Active
+6 | Colin Rooney | `<email>` | `<irc>` | `<SF>` | 07.07.2009 |   | Ireland | Active
+7 | [Michael Judd](https://wiki.adempiere.net/User:Juddm) |   | Michael_Judd | [mjudd](http://sourceforge.net/users/mjudd/) | 07.07.2009 | [www.akunagroup.com](http://www.akunagroup.com/) | England | Active
+8 | Kai Schaeffer | `<email>` | `<irc>` | `<SF>` | 07.07.2009 |   | Germany | Active
+10 | [Mario Calderon](https://wiki.adempiere.net/User:Mar_cal_westf) | [e-mail](mailto:mario.calderon@westfalia-it.com) | MCalderon | [mar_cal_westf](http://sourceforge.net/users/mar_cal_westf) | 07.07.2009 | [www.westfalia-it.com](http://www.westfalia-it.com/) | El Salvador | Active
+11 | Susanne Calderon | [e-mail](mailto:susanne.de.calderon@westfalia-it.com) | `<irc>` | [scalderon](http://sourceforge.net/users/scalderon) | 07.07.2009 | [www.westfalia-it.com](http://www.westfalia-it.com/) | El Salvador | Active
+14 | [Mark Ostermann](https://wiki.adempiere.net/User:Mark_o) | n.a. | mark_o | [mark_o](http://sourceforge.net/users/mark_o) | 07.07.2009 | [www.metas.de](http://www.metas.de/) | Germany | Active
+16 | Steven Sackett | `<email>` | `<irc>` | adaxa | 18.07.2009 | [www.adaxa.com.au](http://www.adaxa.com.au/) | Australia | Active
+21 | [Ramiro Vergara](https://wiki.adempiere.net/User:Rvergara) | [e-mail](mailto:ramiro.vergara@gmail.com) | rvergara | [rvergara](http://sourceforge.net/users/rvergara) | 2.08.2009 |   | Chile | Active
+25 | Allan Howard | [email](mailto:ar_howard@internode.on.net) | ar_howard | ar_howard | 3.08.2009 | [Intouch Direct](http://www.intouchdirect.com.au/) | Australia | Active
+29 | Enrique Ruibal |   |   | ruibal | 6.08.2009 |   | Mexico | Active
+31 | Moisés Quezada |   |   |   | 6.08.2009 |   | Mexico | Active
+33 | [Armen Rizal](https://wiki.adempiere.net/User:Armenrz) |   |   | armenrz | 11.08.2009 |   | Indonesia | Active
+37 | Akos Gabriel | <akos.gabriel@i-logic.hu> |   | gabrielke | 24.08.2009 | [http://i-logic.hu](https://www.ixenit.com/hu) | Hungary | Active
+47 | Kestutis Mikolajunas |   |   | amberis, Kestutis | 24.08.2009 |   |   | Active
+49 | Raouf Mazouz |   |   | raoufmazouz | 24.08.2009 |   |   | Active
+53 | [Alejandro Falcone](https://wiki.adempiere.net/User:Afalcone)  |   | afalcone | [afalcone](http://sourceforge.net/users/afalcone/) | 11.09.2009 | [http://www.openbiz.com.ar](http://www.openbiz.com.ar/) | Argentina | Active
+59 | Evans Armitage |   |   | r035198x | 11.09.2009 |   |   | Active
+69 | Jorge Vallejo |   |   | joredva | 11.09.2009 |   | Ecuador | Active
+88 | Germán Tabares |   |   | gtabaresc | 12.01.2010 |   | Colombia | Active
+97 | Michael Mckay |   | MikeMcKay | mjmckay | 08.04.2011 | - | Canada | Active
+100 | Azzam Othman |   |   | azzamahmad | 16.07.2012 |   |   | Active
+101 | Alberto Abudinen |   |   | albertoabudinen | 16.07.2012 |   |   | Active
+102 | Hilario Fochi |   |   | fochi | 16.07.2012 |   |   | Active
+103 | [Yamel Senih](https://wiki.adempiere.net/User:Yamel_Senih) |   |   | selem | 28.02.2015 | [http://erpcya.com](https://erpya.com/) | Venezuela | Active |
+

--- a/src/community/community-council-team/communication-guidelines.md
+++ b/src/community/community-council-team/communication-guidelines.md
@@ -1,0 +1,27 @@
+---
+title: Communication Guidelines
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Community Details
+  - Community
+article: false
+---
+
+This page is maintained by the [CC Team](community-council-team.md) and the following rules are actively applied according to [Community Governance](./community-governance.md).
+
+1. Please avoid flamewars, trolling, personal attacks, repetitive arguments, advertising
+2. Do not post any messages that are obscene, vulgar, sexually-orientated, hateful, threatening, or otherwise violative of any laws.
+3. Personal attacks on others will not be tolerated.
+4. Flame Wars will not be tolerated.
+5. Do not post if you do not have anything constructive to say in the post.
+6. Challenge others' points of view and opinions, but do so respectfully and thoughtfully ... without insult and personal attack. Differing opinions is one of the things that make this site great.
+7. Do not post the same discussion in more than one forum. Duplicate discussions can be frustrating for other members. Try and pick the most relevant forum for your post.
+8. The best place for your question is the forum. We get a large number of emails. If your email contains a question about ADempiere we will kindly point you to the forums.
+9. There is no selling allowed in the forums.
+10. avoid demanding contributions or cooperation from others
+11. avoid blaming anybody for not contributing or cooperating
+12. these are not intended to exclude kindly inviting anybody to contribute and/or cooperate
+13. When you want to post in another language please use appropiate language forum.
+14. What is private keeps private. Do not take private information or communication to the public.

--- a/src/community/community-council-team/community-council-team.md
+++ b/src/community/community-council-team/community-council-team.md
@@ -1,0 +1,48 @@
+---
+title: Community Council Team
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Community Details
+  - Community
+article: false
+---
+
+The Community Council Team (CC Team) duty is described here [Community Governance](community-governance.md) and we are acting according to [Communication Guidelines](./communication-guidelines.md).
+
+___
+
+## Current CC Team
+
+This Team was accepted by the citizens via vote on 13th of November 2012 [1](https://sourceforge.net/p/adempiere/discussion/611167/thread/23248570/)
+
+- [Karsten Thiemann](https://wiki.adempiere.net/User:Kthiemann), Member (kthiemann) [Email via SF](https://wiki.adempiere.net/ADempiere_ERP)
+
+- [Ricardo Santana](https://wiki.adempiere.net/User:Ralexsander), Member (ralexsander) [Email via SF](https://sourceforge.net/sendmessage.php?touser=1391367)
+
+- [Mario Calderon](https://wiki.adempiere.net/User:Mar_cal_westf), Member (mar_cal_westf) [Email via SF](https://sourceforge.net/sendmessage.php?touser=1683511)
+
+- [Norbert Wessel](https://wiki.adempiere.net/User:Nwessel), Member (nwessel) [Email via SF](https://sourceforge.net/sendmessage.php?touser=1642842)
+
+- [Ramiro Vergara](https://wiki.adempiere.net/User:Rvergara), Member (rvergara) [Email via SF](https://sourceforge.net/sendmessage.php?touser=579980)
+
+## Wiki Team
+
+The wiki team helps to keep the code of conduct and communication guidelines in wiki pages.
+
+**Staff:**
+
+- Michael McKay (McKay)
+
+## Your right to ask CC Team
+
+Community Council obliges itself to answer all questions regarding taken actions and guidelines via private email. In case several community members are requesting the same we may answer in public forum.
+
+## How to contact CC Team
+
+You may contact any member via SF Mail. The SF nick names and mail links are listed right next to the names of CC members.
+
+## Meetings of CC Team
+
+

--- a/src/community/community-council-team/community-governance.md
+++ b/src/community/community-council-team/community-governance.md
@@ -1,0 +1,132 @@
+---
+title: Community Governance
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Community Details
+  - Community
+article: false
+---
+
+::: info Note
+
+This concept was accepted by the citizens via vote on 23 of August 2010 [1](https://sourceforge.net/p/adempiere/discussion/611167/thread/5ab597c4/)
+:::
+
+Current CC Team can be found here: [Community Council Team](./community-council-team.md)
+
+This is a suggestion to create a new body for Community Governance in the ADempiere project as we have learned that we need somebody to take care about they way we talk and work with each other.
+
+Here is the list of people working on the concept and agreeing with it:
+
+- Teo Sarca
+- Joel Stangeland
+- Victor Perez
+- Werner Scharinger
+- Thomas Kreser
+- Mario Calderon
+- Susanne Calderon
+- Kai Schaeffer
+- Karsten Thiemann
+- Mark Ostermann
+- Norbert Wessel
+- Tobias Schöneberg
+- Dirk Niemeyer
+- Dominik Zajac
+
+___
+
+## Community Council
+
+Today we have an entity for controlling technical aspects of the project which is PMC. But we also do have community aspects which is not taken care of a dedicated entity today. Under "community aspects" we see the social part of the project which is mainly communication among us.
+
+We propose a dedicated team for that social side of the project named "Community Council". It consists of members and one head.
+
+The tasks of that team are:
+
+- ensure code of conduct is followed by community members.
+- ensure forum and wiki posts follow the rules set by the community.
+- initiate an escalation in case individuals act against the rules.
+- Setup votes.
+- Maintain citizen list.
+- Define working Procedures for CC.
+- Remove posts that break the rules.
+  - posts can be removed (move to other forum) by community council.
+  - poster should be informed.
+    - on which rule has been broken.
+    - on how he can escalate.
+
+___
+
+## Initial Staffing Process
+
+- Community can propose CC Teams consisting of a CC head and maximum of 5 members
+- After one week citizens vote one of the proposed teams
+
+___
+
+## Election of Community Council
+
+- Candidates can be nominated by any citizen or them self
+- CC Head must approve the nomination
+- Current CC members vote about candidate
+- Membership is for two years
+- Vote of non confidence is applicable
+
+## Election of Community Council Head
+
+Head is voted by the team by > 50% votes
+
+## Escalation Procedure
+
+If a community member breaks the code of conduct this should be the escalation:
+
+- FIRST TIME: CC member informs the community member about him breaking the rules and advises how to behave.
+- SECOND TIME: CC member informs the community member about breaking the rules and announces to him that further incident will lead to escalation and potential consequences.
+- THIRD TIME: CC member initiates a voting in CC Team to ask for excommunication of the trouble maker. If more than 50% vote for exclusion all rights of the disturber gets revoked and he is not allowed to participate in the project for three months. If the vote is even CC head decides about the result. In case nobody is active member (see definition of "active member") of the CC team, CC head can take all decisions by himself.
+- FOURTH TIME: In case the trouble maker is still repeating his behavior after three months he is excluded forever.
+
+Definitions:
+
+- Exclusion: Posts are deleted immediately, permissions are revoked, citizenship is removed
+
+## CC Team - active membership
+
+If a community member works in CC team he is obliged to:
+
+- take part in all CC meetings. In case he is not able to take part he needs to tell in written why.
+- take part in all CC election. In case he is not able to take part he needs to tell in written why or delegate his voting right to somebody else.
+
+If a team member does not follow the rules above two times in a row CC head has the possibility to exclude this non active member from the team by written notice to the team and the non active team member listing the incidents.
+
+## Code of Conduct
+
+Source: [2](https://ubuntu.com/community/ethos/code-of-conduct)
+
+## Mailing lists and web forums
+
+Mailing lists and web forums are an important part of the adempiere community platform. This code of conduct applies to your behavior in those forums too. Please follow these guidelines in addition to the general code of conduct:
+
+- Please use a valid email address to which direct responses can be made.
+- Please avoid flamewars, trolling, personal attacks, repetitive arguments, advertising.
+- On technical matters, the PMC can make a final decision.
+- On matters of community governance, the CC can make a final decision.
+
+## Behavior
+
+This code of conduct covers our behavior as members of the ADempiere Community, in any forum, mailing list, wiki, website, Internet relay chat (IRC) channel, install-fest, public meeting or private correspondence. ADempiere governance bodies are ultimately accountable to the ADempiere Community Council and will arbitrate in any dispute over the conduct of a member of the community.
+
+- Be considerate. Our work will be used by other people, and we in turn will depend on the work of others. Any decision we take will affect users and colleagues, and we should take those consequences into account when making decisions. ADempiere has plenty of users and contributors. Even if it's not obvious at the time, our contributions to ADempiere will impact the work of others. For example, changes to code, infrastructure, policy, documentation and translations during a release may negatively impact others' work.
+
+- Be respectful. The ADempiere community and its members treat one another with respect. Everyone can make a valuable contribution to ADempiere. We may not always agree, but disagreement is no excuse for poor behaviour and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It's important to remember that a community where people feel uncomfortable or threatened is not a productive one. We expect members of the ADempiere community to be respectful when dealing with other contributors as well as with people outside the ADempiere project and with users of ADempiere.
+
+- Be collaborative. Collaboration is central to ADempiere and to the larger free software community. We encourage individuals and teams to work together whether inside or outside the ADempiere Project. This collaboration reduces redundancy, and improves the quality of our work. Internally and externally, we should always be open to collaboration. Wherever possible, we should work closely with upstream projects and others in the free software community to coordinate our efforts in all areas whether they be technical, advocacy or documentation. Our work should be done transparently and we should involve as many interested parties as early as possible. If we decide to take a different approach than others, we will let them know early, document our work and inform others regularly of our progress.
+
+- When we disagree, we consult others. Disagreements, both social and technical, happen all the time and the ADempiere community is no exception. It is important that we resolve disagreements and differing views constructively and with the help of the community and community processes. We have the Project Management Committee, the Community Council which help to decide the right course for ADempiere.
+
+- When we are unsure, we ask for help. Nobody knows everything, and nobody is expected to be perfect in the ADempiere community. Asking questions avoids many problems down the road, and so questions are encouraged. Those who are asked questions should be responsive and helpful. However, when asking a question, care must be taken to do so in an appropriate forum.
+
+- Step down considerately. Members of every project come and go and ADempiere is no different. When somebody leaves or disengages from the project, in whole or in part, we ask that they do so in a way that minimizes disruption to the project. This means they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off.
+
+The ADempiere code of conduct is copied from the ubuntu code of conduct, modified and licensed under the Creative Commons Attribution-Share Alike 3.0 licence.

--- a/src/community/community-detail.md
+++ b/src/community/community-detail.md
@@ -1,0 +1,100 @@
+---
+title: Community Details
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Community Details
+  - Community
+article: false
+---
+
+::: info Note
+
+**STATUS:** Not explicitly ratified by Citizens but in practical use since conference back in 2009. Last updated: Nwessel 14:32, 23 May 2012 (UTC)
+:::
+___
+
+## Overview
+
+ADempiere has always been an open community. If you think of ADempiere as a virtual country - this means there are no border guards - everyone is welcome. You join the community by taking a personal decision to be a part of it. No one can or wants to stop you from taking this decision - in fact we wish that as many people as possible make the choice to join this community.
+
+In the [Berlin Conference 2007](https://www.adempiere.io/about/meeting/berlin-2009.html), we recognised that the decision making process could be improved in the community and this prompted us to think about who was in the community. We recognise that there are many people, end users, system integrators, students, technology enthusiasts, industry and technical experts. In order to improve the decision making process we felt it was important to define and agree how decisions should be taken.
+
+___
+
+## Community Definition
+
+We propose that the community includes people who are more active and people who are less active. For example, some people may come to the community and make a valuable contribution, but for what ever reason may decide not to participate actively again. This can cause problems with a formal decision making process.
+
+We recognise all people as part of the community - you need only to make your own decision to join. We have proposed to recognise people who are more active by granting the privilege of [ADempiere citizen](../community/citizens/citizens.md). An ADempiere citizen will be granted certain rights but will also agree certain obligations. People are free to apply for citizenship as long as they agree with these rights and obligations.
+
+___
+
+## Citizen Rights
+
+- You have the right to vote in all elections
+- You have the right to renounce or give up your citizenship
+
+___
+
+## Citizen Obligations
+
+- Citizen's should use their vote
+- Citizen's should read and agree to the Project Charter
+- Citizen's should be subscribed and read on a regular basis the Citizen Mailing List
+
+___
+
+## How to become a Citizen
+
+- Prospective citizens should be proposed by a current Citizen
+
+- Two supporters who are active Citizens, should write a testimonial in the mailing list to support the application of the prospective citizen. For example, a support might say that the prospective citizen has made some contribution such as:
+  
+  - A new feature.
+  - Some important bug fixes.
+  - Created or maintained some documentation.
+  - Carried out an administrative function - such as press officer.
+
+These are only a small set of examples and we expect to expand and define this over time.
+
+- A new citizen must agree to be a citizen, and get out of the anonymity giving his real name and contact information via this form [Citizen Application Form](../community/citizens/citizen-application-form.md)
+
+- Once two supporters have made their testimonials, an election will be opened, and there will be a period of one week (7 days) from the date of opening of voting in which all Citizens may vote.
+
+- Once the voting period has closed, someone will summarise the result of the vote and declare the election result. If the prospective citizen gains more than 50% of the vote (excluding =0's), then the person becomes an ADempiere citizen.
+
+___
+
+## Voting
+
+`To initiate a vote an email is being sent to the mailling list with following subject line "Call for vote:" <Subject>`
+
+The time window for answering to that call is one week (7 x 24 hours).
+
+You may vote with a +1 which means you agree, a -1 which means you disagree and a =0 which means you abstain, or you have no opinion by responding to the mailing list.
+
+When the week is over or a clear result (e.g. > 50% +1 votes) is achieved, the result is being counted and send with numbers of yes and no votes to the list.
+
+___
+
+## How to renounce your citizenship
+
+- You may renounce your citizenship at any time by making a statement in the Citizen Mailing list.
+
+A proposed statement would be: "I [Insert Name] renounce my citizenship to the Adempiere community". You must be be a citizen in order to renounce your citizenship.
+
+___
+
+## How you might lose your Citizenship
+
+We have discussed that their might be reasons why Citizens might be disciplined, and in extreme cases this might result in someone losing their citizenship.
+
+Reasons proposed why someone might lose citizenship:
+
+- If an active member does not use their right to vote for one month and did not participate int the last three elections they are being removed from their status and the mailing list. They can always get promoted to an active member again later on.
+
+- Flagrant and repetitive breaches of the [project charter](../community/project-charter/project-charter.md) (under review)
+
+We propose that the [Community Council Team](../community/community-council-team/community-council-team.md) be an arbitrator of such cases. In order for someone to lose their citizenship, six people should propose to the mailing list the reasons with evidence why they think a person should lose their citizenship. The community will then announce an election on this proposal and there will be one week (7 days) in which to vote. At the end of the voting period, the voting will be counted and a declaration made. The proposal is passed and the person will lose citizenship if the vote exceeds 50%.

--- a/src/community/project-charter/council.md
+++ b/src/community/project-charter/council.md
@@ -1,0 +1,44 @@
+---
+title: Council
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Community Details
+  - Community
+article: false
+---
+
+::: info Note
+
+Status: This is page is obsolete!
+:::
+
+## What is the council?
+
+Initial definition: The council is the founding group who act as trustess for the community to uphold the ADempiere objectives. In short they work together to foster the community and the development of Adempiere, and represent and promote the ADempiere objectives globally.
+
+According to this new definition [1](https://sourceforge.net/p/adempiere/discussion/611167/thread/b88fbe44/) council is just a museum piece with a founding fathers' status and not be looked upon as active or managerial.
+
+## What are the Adempiere objectives?
+
+see [Project Principles](../project-charter/project-charter.md)
+
+## Who is on the Council?
+
+- [Redhuan D. Oon]((https://wiki.adempiere.net/User:Red1)) aka [Red1](https://wiki.adempiere.net/User:Red1) (Malaysia)
+- [Carlos Ruiz](https://wiki.adempiere.net/User:CarlosRuiz) (Colombia)
+- [Victor Perez](https://wiki.adempiere.net/User:Vpj-cd) (Mexico)
+- [Ramiro Vergara](https://wiki.adempiere.net/User:Rvergara) (Chile)
+- [Trifon Trifonov](https://wiki.adempiere.net/User:Trifonnt) (Bulgaria)
+- [Peter De Zutter](https://wiki.adempiere.net/User:Goanookie) (Belgium)
+- [Alejandro Falcone](https://wiki.adempiere.net/User:Afalcone) (Argentina)
+- [Colin Rooney](https://wiki.adempiere.net/User:Croo) (Ireland)
+- [Joel Stangeland](https://wiki.adempiere.net/User:JsSolutions) (USA)
+- [Michael Judd](https://wiki.adempiere.net/User:Juddm) (United Kingdom) (personal invitation from red1 due to earliest forum Mike has and Accounting specialisation)
+
+## See Also
+
+- [Project Management Committee](https://wiki.adempiere.net/Project_Management_Committee)
+
+- [Team@ADempiere](https://wiki.adempiere.net/index.php?title=Team@ADempiere&action=edit&redlink=1)

--- a/src/community/project-charter/project-charter.md
+++ b/src/community/project-charter/project-charter.md
@@ -1,0 +1,318 @@
+---
+title: Project Charter
+category: Community
+star: 9
+sticky: 9
+tag:
+  - Community Details
+  - Community
+article: false
+---
+
+::: info Note
+
+Status: This is page is obsolete and under review!
+:::
+
+## Overview
+
+This document is a "work in progress". This proposal has been created by a few members but has not yet been approved or voted on by the community as a whole i.e. it does not necessarily represent the current views of the Community yet.
+
+Currently it only describes the ADempiere Project.
+
+### Discussion
+
+- This page and the [Best Practice](https://wiki.adempiere.net/ADempiere_Best_Practices) page is under live discussion by the [Round Table](https://wiki.adempiere.net/2nd_European_ADempiere_Conference#Round_table).
+
+- If you wish to edit anything here, please wait for official resolution from the [2nd European ADempiere Conference](https://wiki.adempiere.net/2nd_European_ADempiere_Conference) now in session.
+
+- However you may continue discussion over any points here at the [Talk:Project_Charter](https://wiki.adempiere.net/Talk:Project_Charter).
+
+### Introduction
+
+The ADempiere Project is a community-based open source software development project dedicated to give members of the expert community a versatile platform, open model and means to provide a robust, full-featured, commercial-quality, and freely available industry suite of Enterprise Resource Planning ("ERP"), Supply Chain Management ("SCM") and Business ("Biz") applications. This document describes the overview, code of conduct, and project management of it.
+
+### Concept
+
+The concept here of community-based is that the originators precisely are so and intend to keep it so. Even though the community came about originally from Compiere ERP/SCM Project in SourceForge, and the code base is derived from there, the ADempiere Project believes that the spirit of Open Source as to uphold the Bazaar model in stark contrast to the Cathedral model which was the direction the original project was driven to. In providing to an assured user base of implementors, subject matter experts and end-users, the ADempiere Project strives to provide all knowledge base free in its own wiki, including choice information of doing business using ADempiere.
+
+By becoming a strong and well supported project, ADempiere becomes the base product for implementors and vendors that sells services around it to operate in a confident and stable environment.
+
+### Culture
+
+A culture is set initially by the SourceForge-Compiere community merely wanting to share their work in an updated and unified code base. The community spirit ensures no single entity controls that. Thus the initial registration of the domain names was amicably entrusted among its advocates, namely www.adempiere.org goes to Redhuan D Oon , adempiere.com goes to CarlosRuiz, [ADempiereforge](http://www.adempiereforge.org/) goes to Trifon Trifonov and the SourceForge-Adempiere goes to Victor Perez, and so forth. In due time, all this collaterals including logo, branding, commercial platform has to be regulated to remain the property of the community and the [Council](../project-charter/council.md) members as mere trustees governed by law.
+
+The manner and lightning pace ADempiere was formed is demonstrative of the resourcefulness expected of a proper Bazaar. The Forking Debate, resolution, introduction of the namesake with his philosophy, slogan, its wikipedia page and other infrastructure was done from start to finish, timestamped in the forum in matter of days as can be seen from the content of the stated domains.
+
+Nevertheless, the applications that are the end-products of this community are meant to serve a much larger worldwide audience of business users that demand a culture of professionalism and organisation that is competitive with other vendor brands such as SAP, JDE, Oracle and Microsoft. Thus members of the community are encouraged and facilitated to sell their own service-based products in a laisserz faire Bazaar fashion.
+
+No favoritism is allowed, either by way of patronage, subscription or membership. The leadership set this up, and gets out of the way. For organisational purposes, the community is represented by an ADempiere Council with a leader chosen by peers and in open forum. In Bazaar sense, further organisation is organic, fluid and self-determined.
+
+## ADempiere Principles
+
+In line with the above aspirations the ADempiere Project will have to adhere to clear and strong principles.
+
+### Non-Profit
+
+ADempiere shall operate as a non-profit organisation, and not support any commercial enterprise directly, favourably or exclusively except where such association is in futherance of the philosophy and culture described in this Charter. In this respect the [Council](../project-charter/council.md) shall set up a Trust Foundation to administer the formal nature of the organisation.
+
+### Contributors Right To Submit
+
+The ADempiere Council and administrators are entrusted to facilitate and manage this project. They must never refuse any contribution that is fair and useful to the codebase. Any contribution or comment can be submitted in proper procedure as adviced by the respective administrators. All submission must honour the creators efforts and any infringement must be corrected within the code and not mean rejection of the code itself for such omission or error of copyright statement. Contributors stand the chance and opportunity to advertise their contributions within ADempiere and their businesses, and among their clientele. Recognised contributors may receive the right of displaying the ADempiere logo and other benefits to assist to that regard.
+
+### Support Of Business Partners
+
+ADempiere shall regard interested vendors and implementors as keen supporters of the Project and shall lend any assistance to allow their succesfull implementation of ADempiere applications among their clients. Adempiere does this by ensuring that the codebase is clean and well updated with submissions and corrections by contributors. Business Partners may contribute through donations or services in kind, that are published and accepted by the Council under clear principle of non-patronage for such contribution.
+
+### Submission To Law
+
+The ADempiere Project and its Council has highest regard for the natural and universal Law of authorship, encompassing the present Licensing Laws as professed commonly in the software industry. It will regard any infringement as a serious breach of code of conduct and disassociate itself from any such acts, and shall make amends to aviod any implications to its Charter.
+
+### Acceptance of Contributions
+
+ADempiere shall accept contributions from any party as long as it is not in contravention of its Charter and not subjugated to support any particular commercial enterprise or branding. Contributions made to it can be declared openly or kept private as to its real author but stated in the books of the Trust Foundation.
+
+Contributions made must be free from conditions and may be in kind such as premises, web-hosting, sponsorships of events and particular modules of the software.
+___
+
+## Project Management
+
+### Mission
+
+The community unabatedly contribute to ADempiere a milieu of application stacks comprising of a number of core model codebases with vertical and integrated addons catering to various and specific industries spanning across trading, organising, manufacturing, service and automation sectors. It intends to be modular and configurable for end-users to pick and choose their needed application. Rather than a "one size fits all", it aims to give "more sizes fit more better". It learns from the mistakes of its predecessor and improve into areas such as more up-to-date architecture, database independence, improved reporting tools, open migration tools and open documentation.
+
+The potential of this project is the explosive growth proven and expected of the community's energy and effort that is self-driven rather than single-handedly run. Emphasising more on the community spirit that originally has given alot to Compiere, it now provides a critical mass of resources to expand in all directions and denominated enough for each and every application needed by the world.
+
+The Project Roadmap draws out the technical challenges and issues for resolution within the Compiere suite. It emphasises use of the latest advancements in application design and development.
+
+Direction and vision of mission... defining what it wants in the future...
+
+### Scope
+
+Elements of the software environment.
+___
+
+### Council
+
+The ADempiere Council is comprised of pioneer founders of the ADempiere Community. Their overall goal is to uphold the principles of the project charter and foster a positive bazaar-like spirit.
+
+#### Responsibilities
+
+- Serve as liaison with the world in representation of the project
+- Approve and uphold the governance rules of the project
+- Promote an open bazaar like environment in all the project structure
+- Legal representation of project corporate entities
+- Define strategic direction of the project
+- Progress and endorse partnerships with commercial entities that support the principles and objectives of the project
+- Hold and protect project assets (passwords, domains, etc)
+- Provide leadership in guiding difficult decisions, resolving problems, removing roadblocks
+- Set a fine example for the community in professional conduct and a contributive spirit
+
+#### Current Members
+
+See [Council]()
+
+## [Project Management Committee](https://wiki.adempiere.net/Project_Management_Committee)
+
+See details [here](https://wiki.adempiere.net/Project_Management_Committee)
+
+### Roles
+
+The Projects under this Charter are operated as meritocracies -- the more you contribute, and the higher the quality of your contribution, the more you are allowed to do. However with this comes increased responsibility.
+
+### Users
+
+Users are the people who use the products that the Project produces. People in this role aren't contributing code, but they are using the products, reporting bugs, and making feature requests and suggestions. Users are encouraged to participate through the user newsgroup(s), asking questions, providing suggestions, and helping other users. Users are also encouraged to report problem reports using the bug tracking system.
+
+### Developers
+
+Users who contribute code or documentation become developers. Developers are the people who contribute code, fixes, documentation, or other work that goes into the product. Developers are also encouraged to participate in the user newsgroup(s), and should monitor the developer mailing list associated with their area of contribution. When appropriate, developers may also contribute to development design discussions related to their area of contribution. Developers are expected to be proactive in reporting problems in the bug tracking system.
+
+### Committers
+
+Developers who give frequent and valuable contributions to a Project, or component of a Project (in the case of large Projects), can have their status promoted to that of a "Committer" for that Project or component respectively. A Committer has write access to the source code repository for the associated Project (or component), and gains voting rights allowing them to affect the future of the Project (or component).
+
+In order for a Developer to become a Committer on a particular Project overseen by the PMC, another Committer for the same Project (or component as appropriate) can nominate that Developer or the Developer can ask to be nominated. Once a Developer is nominated, the Committers for the Project (or component) will vote. If there are at least 3 positive votes and no negative votes, the Developer is recommended to the PMC for commit privileges. If the PMC also approves, the Developer is converted into a Committer and given write access to the source code repository for that Project (or component). Becoming a Committer is a privilege that is earned by contributing and showing discipline and good judgement. It is a responsibility that should be neither given nor taken lightly.
+
+At times, Committers may go inactive for a variety of reasons. The decision making process of the Project relies on active committers who respond to discussions and votes in a constructive and timely manner. The PMC is responsible for ensuring the smooth operation of the Project. A Committer that is disruptive, does not participate actively, or has been inactive for an extended period may have his or her commit status removed by the PMC.
+
+Active participation in the user newsgroup and the appropriate developer mailing lists is a responsibility of all Committers, and is critical to the success of the Project. Committers are required to monitor and contribute to the user newsgroup.
+
+Committers are required to monitor the developer mailing list associated with all Projects and components for which they have commit privileges. This is a condition of being granted commit rights to the Project or component. It is mandatory because committers must participate in votes (which in some cases require a certain minimum number of votes) and must respond to the mailing list in a timely fashion in order to facilitate the smooth operation of the Project. When a Committer is granted commit rights they will be added to the appropriate mailing lists. A Committer must not be unsubscribed from a developer mailing list unless their associated commit privileges are also removed.
+
+Committers are required to track, participate in, and vote on, relevant discussions in their associated Projects and components. There are three voting responses: +1 (yes), -1 (no, or veto), and 0 (abstain).
+
+Committers are responsible for proactively reporting problems in the bug tracking system, and annotating problem reports with status information, explanations, clarifications, or requests for more information from the submitter. Committers are responsible for updating problem reports when they have done work related to the problem.
+
+## Projects
+
+The work under this Top Level Project is further organized into Projects. New Projects must be significant works consistent with the mission of the Top Level Project, be recommended by the PMC, and confirmed by the EMO. Projects can be discontinued by decision of the Board.
+
+When a new Project is created, the PMC nominates a Project lead to act as the technical leader and nominates the initial set of Committers for the Project, and these nominations are approved by the EMO. Project leads are accountable to the PMC for the success of their Project.
+
+### Project Components
+
+The PMC may decide to divide a Project further into components. If a Project is divided into components, commit privileges are normally granted at the component level, and the committers for a given component vote on issues specific to that component. Components are established and discontinued by the PMC. When the PMC creates a component it appoints a component lead to act as the technical leader and names the initial set of Committers for the component. The component lead is designated as a committer for the Project and represents the component in discussions and votes pertaining to the Project as a whole. Component Committers do not participate in votes at the level of the Project as a whole, unless they are also the component lead.
+
+### Ports
+
+For components that contain platform-specific code (such as SWT), it may be advantageous to allow developers to work on a port of the component to a new platform without requiring that they already be committers for the component. In this case the main code base is known as the component "core", and the port code base is known as a component "port". The decision to set up a port is made by the PMC. When a new port of a component is created, the PMC appoints a Port Lead, and an initial set of committers who will have commit and voting privileges specifically for the port. The port is done under the auspices of the core component, and all committers for the core component automatically also have commit and voting privileges on the port. Normally the Component Lead will also be the Port Lead.
+
+### Infrastructure
+
+The PMC works with the EMO to ensure the required infrastructure for the Project. The Project infrastructure will include, at minimum:
+
+Bug Database - Bugzilla database for tracking bugs and feature requests. Source Repository -- One or more CVS repositories containing both the master source code and documentation for the Projects. Website - A website will contain information about the Project, including documentation, downloads of releases, and this Charter. General Mailing List - Mailing list for development discussions pertaining to the Project as a whole or that cross Projects. This mailing list is open to the public. Project Mailing Lists - Development mailing list for technical discussions related to the Project. This mailing list is open to the public. Component Mailing Lists -- Development mailing list for technical discussions related to the component. This mailing list is open to the public. The Development Process Each Project lead must produce a development plan for the release cycle, and the development plan must be approved by the PMC and by a majority of Committers of the Project.
+
+Each Project must identify, and make available on its web site, the requirements and prioritizations it is working against in the current release cycle. In addition, each Project must post a release plan showing the date and content of the next major release, including any major milestones, and must keep this plan up to date.
+
+The Committers of a Project or component decide which changes may be committed to the master code base of a Project or component respectively. Three +1 ('yes' votes) with no -1 ('no' votes or vetoes) are needed to approve a code change. Vetoes must be followed by an explanation for the veto within 24 hours or the veto becomes invalid. All votes are conducted via the developer mailing list associated with the Project or component.
+
+Special rules may be established by the PMC for Projects or components with fewer than three Committers. For efficiency, some code changes from some contributors (e.g. feature additions, bug fixes) may be approved in advance, or approved in principle based on an outline of the work, in which case they may be committed first and changed as needed, with conflicts resolved by majority vote of the Committers of the Project or component, as applicable. More restrictive rules for releasing changes may be established by the PMC near the end of release cycles or for maintenance streams.
+
+The master copy of the code base must reside on the Project web site where it is accessible to all users, developers and committers. Committers must check their changes and new work into the master code base as promptly as possible (subject to any check-in voting rules that may be in effect) in order to foster collaboration among widely distributed groups and so that the latest work is always available to everyone. The PMC is responsible for working with the Eclipse Foundation to establish a release engineering and build process to ensure that builds can be reliably produced on a regular and frequent basis from the master code base and made available for download from the Project web site.
+
+The PMC is responsible for establishing the level of testing appropriate for each Project, and approving the test plans.
+
+All development technical discussions are conducted using the development mailing lists. If discussions are held offline, then a summary must be posted to the mailing list to keep the other committers informed.
+
+### Licensing
+
+All contributions to Projects under this Charter must adhere to the ADempiere Project Intellectual Property Policy.
+
+## Part II
+
+(hereby continuing original work of ADempiere Council..)
+
+**Community Process** (todo)
+
+**ADempiereForge Strategy** During the initial stage of forking, the strategy of source codes committed to our SourceForge is to maintain the present latest versions in use by Compiere users such as 253b where bug fixes are done and committed to SVN.
+
+Other variants or forks of Compiere are housed as separate projects according to their respective owners. The subsequent version and addons of ADempiere will rest on the further work of architects from the various projects' teams.
+
+**Marketing** There is a marketing roadmap to establish ADempiere ERP/CRM/SCM as a viable business suite for commercial and production use.
+
+**Partnership Alliance** If there be any partnership alliance with any commercial entity outside ADempiere, ...
+
+### ADempiere Structure
+
+- The structure of ADempiere
+- Reasons for structuring ADempiere
+- Community discussion
+
+There is some discussion on the proposed structure of [ADempiere here.](https://wiki.adempiere.net/Adempiere_Structure)
+
+## Political
+
+(to be discussed in [talk](https://wiki.adempiere.net/Talk:Project_Charter) page if it is not in agreement as this is only a quick expedient suggestion)
+
+- This section is meant to be more legal standing than the above sections for project administering purposes.
+- It is meant to provide legal certainty and ensure minimal law and order in its due process of natural justice.
+- It is not meant to be too legalistic and any semantic or literal argument beyond the necessary is frown upon as cumbersome and impractical.
+  - It applys the English Common Law's [Mischief Rule](https://en.wikipedia.org/wiki/Mischief_rule) which is, "What if this law did not exist? Would it now remove that mischief before it?".
+
+### Office Bearers
+
+- The bearers of office are:
+  - Founding Council & Leader
+  - PMC & Head
+  - CC & Head
+  - Security Head
+  - Project Admins
+  - Webmaster
+  - Wikimaster
+  - Branch Leaders
+
+- The executive administraton of the project falls under the purview of the PMC and CC which are subjected to periodic elections from the community.
+
+- The PMC in turn can appoint or remove Project Admins and other lesser officers.
+
+### PMC and Commit Committee Policy
+
+- PMC ([Project Management Committee](https://wiki.adempiere.net/Project_Management_Committee)) and CC ([Commit Committee](https://wiki.adempiere.net/Commit_Committee)) may overrule decisions based on technical and urgent situations. In case of conflict with the general community, the PMC may hold an open meeting and only PMC members can vote on the outcome.
+- Community members must abide by rulings of the PMC and CC.
+- PMC may overrule a feature acceptance or stable/non-stable status of any feature.
+- CC may overrule a trunk (stable) commit decision. It may ask the committer to revert successfully failing which it can suspend that committer's right for a short period.
+- Repeat offenders may be subjected to community decision and voting for permanent suspension.
+
+### PMC and CC membership Policy
+
+- PMC and CC members may be suggested and voted in by general community based on their merit and contributions.
+- There should not be a single negative vote from any PMC and CC member to a nominee (to avoid poison and disruption to the ongoing work).
+- If there is a negative vote, the nominator/nominee should address the negativity underlying reasons and try for a nomination again at a later date.
+- Thus though rulings within PMC/CC may be democratic but joining it is not. It has to be meritocracy in order to join the PMC and CC.
+
+### Community Elections
+
+- Thus it is clear that the Community Is Supreme in that it can in a community elections vote in leaders and also vote out leaders in the following elections.
+- If any community member wishes to make changes to PMC and CC membership, can only do so via community elections and any other actions will be deemed illegal.
+- Only the Council or Leader can call for a community elections, failing which a public outcry can force the Leader to do so.
+  - This is also in line with the universal Principle of Separation of Powers in that the Leader has no further executive powers and there are 3 branches of power, namely the People (Community), the Executive (PMC and CC), and the Monarchy (Council or Leader).
+
+### Commit Rights
+
+- Commit Rights is defined as the legal right to commit changes in ADempiere sourcecode to the SVN repository.
+- New commit rights can be granted based on:
+  - Has submitted contribution(s) that is accepted by the PMC or CC members's simple majority vote.
+  - Contributions submitted are in compliance with other rules stated in ADempiere [Best Practice](https://wiki.adempiere.net/ADempiere_Best_Practices);
+  - not on promises of work that are not done or submitted in time. Such rights can be revoked by CC.
+
+- Simple majority is defined as minimally + 1 vote more than -1 votes.
+  - This is for expediency based on current practice.
+- Commit Rights is now granted by the votes of current committers
+- Commit Rights is revoked if developer doesn't commit anything within 30 days
+- Commit Rights can be revoked by simple majority of the rest of committers after a break of any of the rules stated in [Best Practice](https://wiki.adempiere.net/ADempiere_Best_Practices).
+- Commit Rights for branches or under care of sub-projects without rights to 
+- Commit to trunk can be granted by Project Admins with minimal vote.
+
+### Voting Rights
+
+- Only community members who are known and suscribe to this Political Section may vote.
+- New members may be allowed to vote early if they fulfill some basic introduction to make themselves known to the community.
+- Lurker votes can be noted but not counted
+
+  - One who disputes that s/he is a lurker is most likely not a lurker.
+
+- Not everybody can vote for everything - subject matters (see section above for clearer objective rules)
+
+- Inclusion of new code in trunk just can be voted by committers after some peer review
+- New functionalities must be voted by functionals and committers
+- Community issues can be voted by everyone
+
+### Branch Policy
+
+- Sometimes branches may be formed for localised testing away from the main branch or trunk.
+- Prospective branch leaders or maintainers can publish the intent in the forums to gather more support and advice before requesting for it.
+- Only Project Admins can create branches. Other members may request at least one Project Admin for supporting vote before doing so.
+- Branches may have its own branch committers. Again Project Admins can grant those rights if requested.
+- Branch work cannot go to trunk or stable branches under control of Comitt - 
+
+- Committee without prior agreement.
+
+### Freedom To Dispute
+
+- If there are disputes political in nature it should be openly discussed and all sides giving their sincere findings.
+- Any responsible known member of the community may raise a dispute against any authority of PMC and CC in a substantiated manner.
+- No forum discussion can be striken out or deleted unless it is unknown source or containing spam or profanities.
+
+### Arbitration
+
+- If normal open discussion cannot settle a dispute, then arbitation may be seek chaired by any Project Admin not involved in the dispute.
+- Settlement of dispute should be mutually arrived at.
+- Party in conflict must be allowed the time and space to say their say, and no ruling can wipe their words out for the record.
+
+### Final Say
+
+- There is no final say other than the voice of the community.
+- However if the community failed to resolve a matter of contention then the - PMC and CC and Council collectively has final say.
+- A notified maximum limit of 30 days or a full moon is considered a definite failure to act.
+
+### Oath of Support
+
+- To give authority to this Project Charter and its officers in carrying out its contents, community support must be expressed for the sake of unity and responsibility.
+
+- We signed below hereby support this charter:
+
+- [Red1](https://wiki.adempiere.net/User:Red1) 23:29, 10 July 2007 (EDT)
+- [AS](https://wiki.adempiere.net/User:AS) 22:18, 11 July 2007 (EDT)
+- [Mutha](https://wiki.adempiere.net/User:Mutha) 14:22, 20 July 2007 (EAT)


### PR DESCRIPTION
## Added information from [adempiere wiki](https://wiki.adempiere.net) to the documentation

### Added:
- [Community](https://wiki.adempiere.net/Community)
- [Citizens](https://wiki.adempiere.net/Citizens)
- [Citizen Elections](https://wiki.adempiere.net/Citizen_Elections)
- [Cinitizen Inactives](https://wiki.adempiere.net/Citizens_Inactive)
- [Citizen Application Form](https://wiki.adempiere.net/Citizen_Application_Form)
- [Project Charter](https://wiki.adempiere.net/Project_Charter)
- [Community Council Team](https://wiki.adempiere.net/Community_Council_Team)